### PR TITLE
Optional stack arguments to write instructions in folded form

### DIFF
--- a/examples/example.ts
+++ b/examples/example.ts
@@ -26,6 +26,7 @@ import {
   i32x4,
   f64x2,
   table,
+  $,
 } from "../src/index.js";
 import assert from "node:assert";
 import fs from "node:fs";
@@ -51,9 +52,8 @@ let myFunc = func(
   ([x, y], [tmp, i], ctx) => {
     i64.trunc_sat_f64_s(f64.const(1.125));
     call(consoleLog64);
-    i32.const(0);
     local.get(x);
-    i32.add();
+    i32.add($, i32.const(0));
     local.get(y);
     i32.add();
     block({ in: [i32], out: [i32] }, (block) => {

--- a/examples/example.ts
+++ b/examples/example.ts
@@ -52,8 +52,7 @@ let myFunc = func(
   ([x, y], [tmp, i], ctx) => {
     i64.trunc_sat_f64_s(f64.const(1.125));
     call(consoleLog64);
-    local.get(x);
-    i32.add($, i32.const(0));
+    i32.add(local.get(x), i32.const(0));
     local.get(y);
     i32.add();
     block({ in: [i32], out: [i32] }, (block) => {

--- a/examples/example.ts
+++ b/examples/example.ts
@@ -50,23 +50,19 @@ let mem = memory(
 let myFunc = func(
   { in: [i32, i32], locals: [i32, i32], out: [i32] },
   ([x, y], [tmp, i], ctx) => {
-    i64.trunc_sat_f64_s(f64.const(1.125));
+    i64.trunc_sat_f64_s(1.125);
     call(consoleLog64);
-    i32.add(local.get(x), i32.const(0));
-    local.get(y);
-    i32.add();
+    i32.add(x, 0);
+    i32.add($, y);
     block({ in: [i32], out: [i32] }, (block) => {
       local.tee(tmp);
       call(consoleLog);
       loop({}, (loop) => {
         local.get(i);
         call(consoleLog);
-        local.get(i);
-        i32.const(1);
-        i32.add();
+        i32.add(i, 1);
         local.tee(i);
-        i32.const(5);
-        i32.eq();
+        i32.eq($, 5);
         control.if({}, () => {
           local.get(tmp);
           control.return();

--- a/examples/example.ts
+++ b/examples/example.ts
@@ -49,8 +49,7 @@ let mem = memory(
 let myFunc = func(
   { in: [i32, i32], locals: [i32, i32], out: [i32] },
   ([x, y], [tmp, i], ctx) => {
-    f64.const(1.125);
-    i64.trunc_sat_f64_s();
+    i64.trunc_sat_f64_s(f64.const(1.125));
     call(consoleLog64);
     i32.const(0);
     local.get(x);
@@ -84,9 +83,7 @@ let myFunc = func(
       });
       local.get(tmp);
       local.get(tmp);
-      console.log(ctx.stack);
       drop();
-      console.log(ctx.stack);
     });
   }
 );
@@ -156,10 +153,9 @@ let exportedFunc = func(
     v128.const("i32x4", [3, 4, 5, 6]);
     i32x4.add();
     local.set(v);
-    v128.const("f64x2", [0.1, 0.2]);
-    f64.const(6.25);
-    f64x2.splat();
-    f64x2.mul();
+    let $0 = v128.const("f64x2", [0.1, 0.2]);
+    let $1 = f64x2.splat(f64.const(6.25));
+    f64x2.mul($0, $1);
     f64x2.extract_lane(1);
     call(consoleLogF64); // should log 1.25
 

--- a/examples/example.wat
+++ b/examples/example.wat
@@ -60,8 +60,8 @@
     f64.const 0x1.2p+0 (;=1.125;)
     i64.trunc_sat_f64_s
     call 0
-    i32.const 0
     local.get 0
+    i32.const 0
     i32.add
     local.get 1
     i32.add

--- a/src/func.ts
+++ b/src/func.ts
@@ -8,6 +8,7 @@ import {
   FunctionIndex,
   FunctionType,
   JSValue,
+  Local,
   Type,
   TypeIndex,
   ValueType,
@@ -125,8 +126,6 @@ type JSFunctionType<T extends FunctionType> = JSFunctionType_<
   T["args"],
   T["results"]
 >;
-
-type Local<L extends ValueType> = { type?: L; index: number };
 
 type ToLocal<T extends Tuple<ValueType>> = {
   [K in keyof T]: Local<T[K]>;

--- a/src/func.ts
+++ b/src/func.ts
@@ -55,9 +55,15 @@ function func<
     results: resultsArray as any,
   };
   let nArgs = argsArray.length;
-  let argsInput = argsArray.map((_, index) => ({ index })) as ToLocal<Args>;
+  let argsInput = argsArray.map((type, index) => ({
+    type,
+    index,
+  })) as ToLocal<Args>;
   let { sortedLocals, localIndices } = sortLocals(localsArray, nArgs);
-  let localsInput = localIndices.map((index) => ({ index })) as ToLocal<Locals>;
+  let localsInput = localIndices.map((index, j) => ({
+    type: localsArray[j],
+    index,
+  })) as ToLocal<Locals>;
   let stack: ValueType[] = [];
   let { body, deps } = withContext(
     ctx,

--- a/src/index.ts
+++ b/src/index.ts
@@ -90,6 +90,7 @@ export { func, defaultCtx, Func, Local };
 export {
   funcref,
   externref,
+  $,
   Type,
   ValueType,
   ValueTypeObject,
@@ -146,6 +147,8 @@ let {
   call,
   call_indirect,
 } = control;
+
+const $: Type<any> = { kind: "unknown" };
 
 function createInstructions(ctx: LocalContext) {
   const func = removeContext(ctx, originalFunc);

--- a/src/index.ts
+++ b/src/index.ts
@@ -156,7 +156,7 @@ function createInstructions(ctx: LocalContext) {
   const i64 = Object.assign(i64t, removeContexts(ctx, i64Ops));
   const f32 = Object.assign(f32t, removeContexts(ctx, f32Ops));
   const f64 = Object.assign(f64t, removeContexts(ctx, f64Ops));
-  const local = removeContexts(ctx, localOps);
+  const local = localOps(ctx);
   const global = Object.assign(
     globalConstructor,
     removeContexts(ctx, globalOps)

--- a/src/index.ts
+++ b/src/index.ts
@@ -98,7 +98,7 @@ export {
 };
 export { importFunc, importGlobal };
 export { Const, Dependency };
-export type { ToTypeTuple, FunctionTypeInput, Label, TupleN };
+export type { ToTypeTuple, FunctionTypeInput, Label, TupleN, Instruction };
 
 type i32 = "i32";
 type i64 = "i64";
@@ -216,7 +216,7 @@ function createInstructions(ctx: LocalContext) {
 
 function removeContexts<
   T extends {
-    [K in any]: (ctx: LocalContext, ...args: any) => Instruction<any, any>;
+    [K in any]: (ctx: LocalContext, ...args: any) => any;
   }
 >(
   ctx: LocalContext,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,9 @@
 export { Module } from "./module.js";
 import {
-  localOps,
   globalOps,
   globalConstructor,
   refOps,
+  bindLocalOps,
 } from "./instruction/variable.js";
 import { f32Ops, f64Ops, i32Ops, i64Ops } from "./instruction/numeric.js";
 import { memoryOps, dataOps, tableOps, elemOps } from "./instruction/memory.js";
@@ -156,7 +156,7 @@ function createInstructions(ctx: LocalContext) {
   const i64 = Object.assign(i64t, removeContexts(ctx, i64Ops));
   const f32 = Object.assign(f32t, removeContexts(ctx, f32Ops));
   const f64 = Object.assign(f64t, removeContexts(ctx, f64Ops));
-  const local = localOps(ctx);
+  const local = bindLocalOps(ctx);
   const global = Object.assign(
     globalConstructor,
     removeContexts(ctx, globalOps)

--- a/src/instruction/base.ts
+++ b/src/instruction/base.ts
@@ -10,6 +10,7 @@ import {
 import {
   FunctionType,
   Type,
+  valueType,
   ValueType,
   valueTypeLiterals,
   ValueTypeObject,
@@ -111,8 +112,8 @@ function baseInstruction<
       results.length === 0
         ? undefined
         : results.length === 1
-        ? results[0]
-        : results
+        ? valueType(results[0])
+        : results.map(valueType)
     ) as Instruction_<Args, Results>;
   };
 }

--- a/src/instruction/base.ts
+++ b/src/instruction/base.ts
@@ -20,7 +20,6 @@ import { Tuple } from "../util.js";
 import { InstructionName, nameToOpcode } from "./opcodes.js";
 
 export {
-  instruction,
   instructionWithArg,
   baseInstruction,
   BaseInstruction,
@@ -35,6 +34,7 @@ export {
   typeFromInput,
   Instruction,
   isInstruction,
+  Instruction_,
 };
 
 const nameToInstruction: Record<string, BaseInstruction> = {};
@@ -133,46 +133,6 @@ type Instruction_<Args, Results> = Results extends []
   : Results extends [ValueType]
   ? Type<Results[0]>
   : Instruction<Args, Results>;
-
-type t = Instruction_<["i32"], ["i32"]>;
-
-/**
- * instruction that is completely fixed
- */
-function instruction<
-  Args extends Tuple<ValueType>,
-  Results extends Tuple<ValueType>
->(
-  string: InstructionName,
-  args: ValueTypeObjects<Args>,
-  results: ValueTypeObjects<Results>
-): ((ctx: LocalContext, ...args: [] | Args) => any) extends (
-  ctx: LocalContext,
-  ...args: infer P
-) => any
-  ? (
-      ctx: LocalContext,
-      ...args: {
-        [i in keyof P]: Type<P[i]>;
-      }
-    ) => Instruction_<Args, Results>
-  : never {
-  let instr = { in: valueTypeLiterals(args), out: valueTypeLiterals(results) };
-  let createInstr = baseInstruction<undefined, [], [], Args, Results>(
-    string,
-    Undefined,
-    { create: () => instr }
-  );
-  return function (
-    ctx: LocalContext,
-    ...args: [] | (ValueTypeObjects<Args> & any[])
-  ): Instruction_<Args, Results> {
-    if (args.length !== 0) {
-      // TODO do some checks on the args
-    }
-    return createInstr(ctx);
-  } as any;
-}
 
 /**
  * instruction of constant type without dependencies,

--- a/src/instruction/const.ts
+++ b/src/instruction/const.ts
@@ -1,0 +1,10 @@
+import { F32, F64, I32, I64 } from "../immediate.js";
+import { instructionWithArg } from "./base.js";
+import { i32t, i64t, f32t, f64t } from "../types.js";
+
+export { i32Const, i64Const, f32Const, f64Const };
+
+const i32Const = instructionWithArg("i32.const", I32, [], [i32t]);
+const i64Const = instructionWithArg("i64.const", I64, [], [i64t]);
+const f32Const = instructionWithArg("f32.const", F32, [], [f32t]);
+const f64Const = instructionWithArg("f64.const", F64, [], [f64t]);

--- a/src/instruction/numeric.ts
+++ b/src/instruction/numeric.ts
@@ -1,7 +1,9 @@
 import { F32, F64, I32, I64 } from "../immediate.js";
-import { instruction, instructionWithArg } from "./base.js";
+import { instructionWithArg } from "./base.js";
 import { i32t, i64t, f32t, f64t } from "../types.js";
 import { memoryInstruction } from "./memory.js";
+import { instruction } from "./stack-args.js";
+import { f32Const, f64Const, i32Const, i64Const } from "./const.js";
 
 export { i32Ops, i64Ops, f32Ops, f64Ops };
 
@@ -17,7 +19,7 @@ const i32Ops = {
   store8: memoryInstruction("i32.store8", 8, [i32t, i32t], []),
 
   // const
-  const: instructionWithArg("i32.const", I32, [], [i32t]),
+  const: i32Const,
 
   // comparison
   eqz: instruction("i32.eqz", [i32t], [i32t]),
@@ -86,7 +88,7 @@ const i64Ops = {
   store8: memoryInstruction("i64.store8", 8, [i32t, i64t], []),
 
   // const
-  const: instructionWithArg("i64.const", I64, [], [i64t]),
+  const: i64Const,
 
   // comparison
   eqz: instruction("i64.eqz", [i64t], [i32t]),
@@ -148,7 +150,7 @@ const f32Ops = {
   store: memoryInstruction("f32.store", 32, [i32t, f32t], []),
 
   // const
-  const: instructionWithArg("f32.const", F32, [], [f32t]),
+  const: f32Const,
 
   // comparison
   eq: instruction("f32.eq", [f32t, f32t], [i32t]),
@@ -191,7 +193,7 @@ const f64Ops = {
   store: memoryInstruction("f64.store", 64, [i32t, f64t], []),
 
   // const
-  const: instructionWithArg("f64.const", F64, [], [f64t]),
+  const: f64Const,
 
   // comparison
   eq: instruction("f64.eq", [f64t, f64t], [i32t]),

--- a/src/instruction/stack-args.ts
+++ b/src/instruction/stack-args.ts
@@ -1,0 +1,115 @@
+import { Undefined } from "../binable.js";
+import { LocalContext } from "../local-context.js";
+import {
+  JSValue,
+  Local,
+  Type,
+  ValueType,
+  valueTypeLiterals,
+  ValueTypeObjects,
+} from "../types.js";
+import { Tuple } from "../util.js";
+import { Instruction_, baseInstruction } from "./base.js";
+import { f32Const, f64Const, i32Const, i64Const } from "./const.js";
+import { InstructionName } from "./opcodes.js";
+import { localOps } from "./variable.js";
+
+export { instruction };
+
+type Input<T> = Type<T> | Local<T> | JSValue<T>;
+
+function isLocal(x: any): x is Local<ValueType> {
+  return typeof x === "object" && x !== null && "index" in x;
+}
+function isType(x: any): x is Type<ValueType | "unknown"> {
+  return typeof x === "object" && x !== null && "kind" in x;
+}
+
+/**
+ * instruction that is completely fixed
+ */
+function instruction<
+  Args extends Tuple<ValueType>,
+  Results extends Tuple<ValueType>
+>(
+  string: InstructionName,
+  args: ValueTypeObjects<Args>,
+  results: ValueTypeObjects<Results>
+): ((ctx: LocalContext, ...args: [] | Args) => any) extends (
+  ctx: LocalContext,
+  ...args: infer P
+) => any
+  ? (
+      ctx: LocalContext,
+      ...args: {
+        [i in keyof P]: Input<P[i]>;
+      }
+    ) => Instruction_<Args, Results>
+  : never {
+  let instr = { in: valueTypeLiterals(args), out: valueTypeLiterals(results) };
+  let createInstr = baseInstruction<undefined, [], [], Args, Results>(
+    string,
+    Undefined,
+    { create: () => instr }
+  );
+  function createInstr_(
+    ctx: LocalContext,
+    ...actualArgs: Input<ValueType>[]
+  ): Instruction_<Args, Results> {
+    let n = instr.in.length;
+    if (actualArgs.length !== 0 && actualArgs.length !== n) {
+      throw Error(
+        `${string}: Expected 0 or ${n} arguments, got ${actualArgs.length}.`
+      );
+    }
+    if (actualArgs.length !== 0) {
+      for (let i = 0; i < n; i++) {
+        let x = actualArgs[i];
+        let type = instr.in[i];
+        if (isLocal(x)) {
+          if (x.type !== type)
+            throw Error(
+              `${string}: Expected type ${type}, got local of type ${x.type}.`
+            );
+          localOps.get(ctx, x);
+        } else if (isType(x)) {
+          if (x.kind !== type && x.kind !== "unknown")
+            throw Error(
+              `${string}: Expected argument of type ${type}, got ${x.kind}.`
+            );
+        } else {
+          // could be const
+          console.log({ type, x });
+          let Unsupported = Error(
+            `${string}: Unsupported input for type ${type}, got ${x}.`
+          );
+          switch (type) {
+            case "i32":
+              if (typeof x !== "number") throw Unsupported;
+              i32Const(ctx, x);
+              break;
+            case "i64":
+              if (typeof x !== "bigint") throw Unsupported;
+              i64Const(ctx, x);
+              break;
+            case "f32":
+              if (typeof x !== "number") throw Unsupported;
+              f32Const(ctx, x);
+              break;
+            case "f64":
+              if (typeof x !== "number") throw Unsupported;
+              f64Const(ctx, x);
+              break;
+            case "v128":
+            case "funcref":
+            case "externref":
+            default:
+              throw Unsupported;
+          }
+        }
+      }
+    }
+    return createInstr(ctx);
+  }
+  return createInstr_ as any;
+}

--- a/src/instruction/variable.ts
+++ b/src/instruction/variable.ts
@@ -13,12 +13,12 @@ import {
 } from "../types.js";
 import { LocalContext } from "../local-context.js";
 
-export { localOps, globalOps, globalConstructor, refOps };
+export { localOps, bindLocalOps, globalOps, globalConstructor, refOps };
 
 type AnyLocal = Local<ValueType>;
 
-function localOps(ctx: LocalContext) {
-  const get = baseInstruction("local.get", U32, {
+const localOps = {
+  get: baseInstruction("local.get", U32, {
     create({ locals }, x: AnyLocal) {
       let local = locals[x.index];
       if (local === undefined)
@@ -26,8 +26,8 @@ function localOps(ctx: LocalContext) {
       return { in: [], out: [local] };
     },
     resolve: (_, x: AnyLocal) => x.index,
-  });
-  const set = baseInstruction("local.set", U32, {
+  }),
+  set: baseInstruction("local.set", U32, {
     create({ locals }, x: AnyLocal) {
       let local = locals[x.index];
       if (local === undefined)
@@ -35,8 +35,8 @@ function localOps(ctx: LocalContext) {
       return { in: [local], out: [] };
     },
     resolve: (_, x: AnyLocal) => x.index,
-  });
-  const tee = baseInstruction("local.tee", U32, {
+  }),
+  tee: baseInstruction("local.tee", U32, {
     create({ locals }, x: AnyLocal) {
       let type = locals[x.index];
       if (type === undefined)
@@ -44,17 +44,19 @@ function localOps(ctx: LocalContext) {
       return { in: [type], out: [type] };
     },
     resolve: (_, x: AnyLocal) => x.index,
-  });
+  }),
+};
 
+function bindLocalOps(ctx: LocalContext) {
   return {
     get: function <T extends ValueType>(x: Local<T>) {
-      return get(ctx, x) as Type<T>;
+      return localOps.get(ctx, x) as Type<T>;
     },
     set: function <T extends ValueType>(x: Local<T>) {
-      return set(ctx, x);
+      return localOps.set(ctx, x);
     },
     tee: function <T extends ValueType>(x: Local<T>) {
-      return tee(ctx, x) as Type<T>;
+      return localOps.tee(ctx, x) as Type<T>;
     },
   };
 }

--- a/src/instruction/vector.ts
+++ b/src/instruction/vector.ts
@@ -1,10 +1,11 @@
 import { F32, F64, U8 } from "../immediate.js";
-import { baseInstruction, instruction, instructionWithArg } from "./base.js";
+import { baseInstruction, instructionWithArg } from "./base.js";
 import { i32t, i64t, f32t, f64t, v128t } from "../types.js";
 import { memoryLaneInstruction, memoryInstruction } from "./memory.js";
 import { array, Byte } from "../binable.js";
 import { TupleN } from "../util.js";
 import { LocalContext } from "../local-context.js";
+import { instruction } from "./stack-args.js";
 
 export {
   v128Ops,

--- a/src/types.ts
+++ b/src/types.ts
@@ -21,6 +21,7 @@ export {
   ValueType,
   RefType,
   Type,
+  Local,
   ResultType,
   invertRecord,
   valueType,
@@ -38,6 +39,8 @@ type RefType = "funcref" | "externref";
 type ValueType = "i32" | "i64" | "f32" | "f64" | "v128" | RefType;
 
 type Type<L> = { kind: L };
+type Local<L extends ValueType> = { type?: L; index: number };
+
 function valueTypeLiteral<L extends ValueType>({ kind }: { kind: L }): L {
   return kind;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -39,7 +39,7 @@ type RefType = "funcref" | "externref";
 type ValueType = "i32" | "i64" | "f32" | "f64" | "v128" | RefType;
 
 type Type<L> = { kind: L };
-type Local<L extends ValueType> = { type?: L; index: number };
+type Local<L extends ValueType> = { type: L; index: number };
 
 function valueTypeLiteral<L extends ValueType>({ kind }: { kind: L }): L {
   return kind;

--- a/src/types.ts
+++ b/src/types.ts
@@ -39,7 +39,7 @@ type RefType = "funcref" | "externref";
 type ValueType = "i32" | "i64" | "f32" | "f64" | "v128" | RefType;
 
 type Type<L> = { kind: L };
-type Local<L extends ValueType> = { type: L; index: number };
+type Local<L> = { type: L; index: number };
 
 function valueTypeLiteral<L extends ValueType>({ kind }: { kind: L }): L {
   return kind;
@@ -186,7 +186,7 @@ function printFunctionType({ args, results }: FunctionType) {
 
 // infer JS values
 
-type JSValue<T extends ValueType> = T extends "i32"
+type JSValue<T> = T extends "i32"
   ? number
   : T extends "f32"
   ? number

--- a/src/types.ts
+++ b/src/types.ts
@@ -42,7 +42,7 @@ function valueTypeLiteral<L extends ValueType>({ kind }: { kind: L }): L {
   return kind;
 }
 type ValueTypeObjects<T extends Tuple<ValueType>> = {
-  [i in keyof T]: { kind: T[i] };
+  [i in keyof T]: Type<T[i]>;
 };
 function valueType<L extends ValueType>(kind: L): Type<L> {
   return { kind };


### PR DESCRIPTION
TODO: to make this a usable first step, need to infer at least types of locals and globals returned by `local.get` etc

Plus, automatically insert `local.get` and `{i32,i64,f32,f64}.const` instructions