### PR TITLE
More stack arguments

### DIFF
--- a/examples/example.ts
+++ b/examples/example.ts
@@ -55,13 +55,12 @@ let myFunc = func(
     i32.add(x, 0);
     i32.add($, y);
     block({ in: [i32], out: [i32] }, (block) => {
-      local.tee(tmp);
+      local.tee(tmp, $);
       call(consoleLog);
       loop({}, (loop) => {
         local.get(i);
         call(consoleLog);
-        i32.add(i, 1);
-        local.tee(i);
+        local.tee(i, i32.add(i, 1));
         i32.eq($, 5);
         control.if({}, () => {
           local.get(tmp);
@@ -85,7 +84,7 @@ let myFunc = func(
 
 let importedGlobal = importGlobal(i64, 1000n);
 let myFuncGlobal = global(Const.refFunc(myFunc));
-let f64Global = global(Const.f64(1.001));
+let f64Global = global(Const.f64(0), { mutable: true });
 
 let testUnreachable = func({ in: [], locals: [], out: [] }, () => {
   unreachable();
@@ -114,7 +113,8 @@ let exportedFunc = func(
     global.get(myFuncGlobal);
     i32.const(0);
     call_indirect(funcTable, { in: [funcref], out: [] });
-    f64.mul(f64.const(1.01), f64Global);
+    global.set(f64Global, 1.001);
+    f64.mul(1.01, f64Global);
     call(consoleLogF64);
     local.get(x);
     local.get(doLog);
@@ -149,8 +149,7 @@ let exportedFunc = func(
     // test vector instr
     v128.const("i64x2", [1n, 2n]);
     v128.const("i32x4", [3, 4, 5, 6]);
-    i32x4.add();
-    local.set(v);
+    local.set(v, i32x4.add());
     let $0 = v128.const("f64x2", [0.1, 0.2]);
     let $1 = f64x2.splat(f64.const(6.25));
     f64x2.mul($0, $1);

--- a/examples/example.ts
+++ b/examples/example.ts
@@ -85,6 +85,7 @@ let myFunc = func(
 
 let importedGlobal = importGlobal(i64, 1000n);
 let myFuncGlobal = global(Const.refFunc(myFunc));
+let f64Global = global(Const.f64(1.001));
 
 let testUnreachable = func({ in: [], locals: [], out: [] }, () => {
   unreachable();
@@ -113,6 +114,8 @@ let exportedFunc = func(
     global.get(myFuncGlobal);
     i32.const(0);
     call_indirect(funcTable, { in: [funcref], out: [] });
+    f64.mul(global.get(f64Global), f64.const(1.01));
+    call(consoleLogF64);
     local.get(x);
     local.get(doLog);
     control.if(null, () => {

--- a/examples/example.ts
+++ b/examples/example.ts
@@ -114,7 +114,7 @@ let exportedFunc = func(
     global.get(myFuncGlobal);
     i32.const(0);
     call_indirect(funcTable, { in: [funcref], out: [] });
-    f64.mul(global.get(f64Global), f64.const(1.01));
+    f64.mul(f64.const(1.01), f64Global);
     call(consoleLogF64);
     local.get(x);
     local.get(doLog);

--- a/examples/example.ts
+++ b/examples/example.ts
@@ -142,8 +142,7 @@ let exportedFunc = func(
 
     // move int32 at location 4 to location 0
     i32.const(0);
-    i32.const(0);
-    i32.load({ offset: 4 });
+    i32.load({ offset: 4 }, 0);
     i32.store({});
 
     // test vector instr

--- a/examples/example.wat
+++ b/examples/example.wat
@@ -19,8 +19,8 @@
     global.get 1
     i32.const 0
     call_indirect (type 2)
-    global.get 2
     f64.const 0x1.028f5c28f5c29p+0 (;=1.01;)
+    global.get 2
     f64.mul
     call 3
     local.get 0

--- a/examples/example.wat
+++ b/examples/example.wat
@@ -19,6 +19,8 @@
     global.get 1
     i32.const 0
     call_indirect (type 2)
+    f64.const 0x1.004189374bc6ap+0 (;=1.001;)
+    global.set 2
     f64.const 0x1.028f5c28f5c29p+0 (;=1.01;)
     global.get 2
     f64.mul
@@ -98,7 +100,7 @@
   (table (;0;) 4 funcref)
   (memory (;0;) 1 65536)
   (global (;1;) funcref (ref.func 6))
-  (global (;2;) f64 (f64.const 0x1.004189374bc6ap+0 (;=1.001;)))
+  (global (;2;) (mut f64) (f64.const 0x0p+0 (;=0;)))
   (export "exportedFunc" (func 5))
   (export "importedGlobal" (global 0))
   (export "memory" (memory 0))

--- a/examples/example.wat
+++ b/examples/example.wat
@@ -19,6 +19,10 @@
     global.get 1
     i32.const 0
     call_indirect (type 2)
+    global.get 2
+    f64.const 0x1.028f5c28f5c29p+0 (;=1.01;)
+    f64.mul
+    call 3
     local.get 0
     local.get 1
     if  ;; label = @1
@@ -94,6 +98,7 @@
   (table (;0;) 4 funcref)
   (memory (;0;) 1 65536)
   (global (;1;) funcref (ref.func 6))
+  (global (;2;) f64 (f64.const 0x1.004189374bc6ap+0 (;=1.001;)))
   (export "exportedFunc" (func 5))
   (export "importedGlobal" (global 0))
   (export "memory" (memory 0))

--- a/src/export.ts
+++ b/src/export.ts
@@ -22,7 +22,7 @@ type ExternType =
   | { kind: "function"; value: FunctionType }
   | { kind: "table"; value: TableType }
   | { kind: "memory"; value: MemoryType }
-  | { kind: "global"; value: GlobalType };
+  | { kind: "global"; value: GlobalType<ValueType> };
 
 type ExportDescription = {
   kind: "function" | "table" | "memory" | "global";
@@ -47,12 +47,12 @@ type ImportDescription =
   | { kind: "function"; value: TypeIndex }
   | { kind: "table"; value: TableType }
   | { kind: "memory"; value: MemoryType }
-  | { kind: "global"; value: GlobalType };
+  | { kind: "global"; value: GlobalType<ValueType> };
 const ImportDescription: Binable<ImportDescription> = byteEnum<{
   0x00: { kind: "function"; value: TypeIndex };
   0x01: { kind: "table"; value: TableType };
   0x02: { kind: "memory"; value: MemoryType };
-  0x03: { kind: "global"; value: GlobalType };
+  0x03: { kind: "global"; value: GlobalType<ValueType> };
 }>({
   0x00: { kind: "function", value: TypeIndex },
   0x01: { kind: "table", value: TableType },
@@ -94,7 +94,7 @@ function importGlobal<V extends ValueType>(
   type: Type<V>,
   value: JSValue<V>,
   { mutable = false } = {}
-): Dependency.ImportGlobal {
+): Dependency.ImportGlobal<V> {
   let globalType = { value: valueTypeLiteral(type), mutable };
   let valueType: WebAssembly.ValueType =
     type.kind === "funcref" ? "anyfunc" : type.kind;

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import {
   globalConstructor,
   refOps,
   bindLocalOps,
+  bindGlobalOps,
 } from "./instruction/variable.js";
 import { f32Ops, f64Ops, i32Ops, i64Ops } from "./instruction/numeric.js";
 import { memoryOps, dataOps, tableOps, elemOps } from "./instruction/memory.js";
@@ -157,10 +158,7 @@ function createInstructions(ctx: LocalContext) {
   const f32 = Object.assign(f32t, removeContexts(ctx, f32Ops));
   const f64 = Object.assign(f64t, removeContexts(ctx, f64Ops));
   const local = bindLocalOps(ctx);
-  const global = Object.assign(
-    globalConstructor,
-    removeContexts(ctx, globalOps)
-  );
+  const global = Object.assign(globalConstructor, bindGlobalOps(ctx));
   const ref = removeContexts(ctx, refOps);
   const control = removeContexts(ctx, controlOps);
   const { drop, select_poly, select_t } = removeContexts(ctx, parametric);

--- a/src/instruction/stack-args.ts
+++ b/src/instruction/stack-args.ts
@@ -94,7 +94,7 @@ function instruction<
         } else if (isGlobal(x)) {
           if (x.type.value !== type)
             throw Error(
-              `${string}: Expected type ${type}, got global of type ${x.type}.`
+              `${string}: Expected type ${type}, got global of type ${x.type.value}.`
             );
           globalOps.get(ctx, x);
         } else if (isType(x)) {

--- a/src/instruction/stack-args.ts
+++ b/src/instruction/stack-args.ts
@@ -54,10 +54,7 @@ function instruction<
   string: InstructionName,
   args: ValueTypeObjects<Args>,
   results: ValueTypeObjects<Results>
-): ((ctx: LocalContext, ...args: [] | Args) => any) extends (
-  ctx: LocalContext,
-  ...args: infer P
-) => any
+): ((...args: [] | Args) => any) extends (...args: infer P) => any
   ? (
       ctx: LocalContext,
       ...args: {

--- a/src/instruction/variable-get.ts
+++ b/src/instruction/variable-get.ts
@@ -1,0 +1,29 @@
+import * as Dependency from "../dependency.js";
+import { U32 } from "../immediate.js";
+import { baseInstruction } from "./base.js";
+import { Local, ValueType } from "../types.js";
+
+export { localGet, globalGet };
+
+type AnyLocal = Local<ValueType>;
+
+const localGet = baseInstruction("local.get", U32, {
+  create({ locals }, x: AnyLocal) {
+    let local = locals[x.index];
+    if (local === undefined)
+      throw Error(`local with index ${x.index} not available`);
+    return { in: [], out: [local] };
+  },
+  resolve: (_, x: AnyLocal) => x.index,
+});
+
+const globalGet = baseInstruction("global.get", U32, {
+  create(_, global: Dependency.AnyGlobal<ValueType>) {
+    return {
+      in: [],
+      out: [global.type.value],
+      deps: [global],
+    };
+  },
+  resolve: ([globalIdx]) => globalIdx,
+});

--- a/src/memory-binable.ts
+++ b/src/memory-binable.ts
@@ -11,16 +11,16 @@ import {
 import { U32, vec } from "./immediate.js";
 import { ConstExpression, Expression } from "./instruction/binable.js";
 import {
-  funcref,
   FunctionIndex,
   GlobalType,
   RefType,
   TableIndex,
+  ValueType,
 } from "./types.js";
 
 export { Global, Data, Elem };
 
-type Global = { type: GlobalType; init: ConstExpression };
+type Global = { type: GlobalType<ValueType>; init: ConstExpression };
 const Global = record<Global>({ type: GlobalType, init: ConstExpression });
 
 type Data = {

--- a/src/memory.ts
+++ b/src/memory.ts
@@ -1,6 +1,11 @@
 import { Const } from "./dependency.js";
 import * as Dependency from "./dependency.js";
-import { RefTypeObject, valueTypeLiteral } from "./types.js";
+import {
+  RefType,
+  RefTypeObject,
+  ValueType,
+  valueTypeLiteral,
+} from "./types.js";
 
 export {
   memoryConstructor,
@@ -36,7 +41,7 @@ function dataConstructor(
   mode:
     | {
         memory?: Dependency.AnyMemory;
-        offset: Const.i32 | Const.globalGet;
+        offset: Const.i32 | Const.globalGet<"i32">;
       }
     | "passive",
   [...init]: number[] | Uint8Array
@@ -45,7 +50,7 @@ function dataConstructor(
     return { kind: "data", init, mode, deps: [] };
   }
   let { memory, offset } = mode;
-  let deps = [...offset.deps] as Dependency.AnyGlobal[];
+  let deps = [...offset.deps] as Dependency.AnyGlobal<ValueType>[];
   let result: Dependency.Data = {
     kind: "data",
     init,
@@ -71,7 +76,7 @@ function tableConstructor(
     min: number;
     max?: number;
   },
-  content?: (Const.refFunc | Const.refNull)[]
+  content?: (Const.refFunc | Const.refNull<RefType>)[]
 ): Dependency.Table {
   let table = {
     kind: "table" as const,
@@ -95,10 +100,10 @@ function elemConstructor(
       | "declarative"
       | {
           table: Dependency.AnyTable;
-          offset: Const.i32 | Const.globalGet;
+          offset: Const.i32 | Const.globalGet<"i32">;
         };
   },
-  init: (Const.refFunc | Const.refNull)[]
+  init: (Const.refFunc | Const.refNull<RefType>)[]
 ): Dependency.Elem {
   let deps = init.flatMap((i) => i.deps as Dependency.Elem["deps"]);
   let result = {

--- a/src/module-binable.ts
+++ b/src/module-binable.ts
@@ -17,6 +17,7 @@ import {
   GlobalType,
   MemoryType,
   TableType,
+  ValueType,
   ValueTypeObject,
 } from "./types.js";
 import { Export, Import } from "./export.js";
@@ -243,7 +244,7 @@ type ValidationContext = {
   funcs: FunctionType[];
   tables: TableType[];
   memories: MemoryType[];
-  globals: GlobalType[];
+  globals: GlobalType<ValueType>[];
   elems: Elem[];
   datas: Data[];
   locals: ValueTypeObject[];

--- a/src/module.ts
+++ b/src/module.ts
@@ -10,6 +10,7 @@ import {
   Limits,
   MemoryType,
   TableType,
+  ValueType,
 } from "./types.js";
 import { memoryConstructor } from "./memory.js";
 
@@ -213,7 +214,7 @@ type NiceExports<Exports extends Record<string, Dependency.Export>> = {
 type NiceExport<Export extends Dependency.Export> =
   Export extends Dependency.AnyFunc
     ? JSFunctionType<Export["type"]>
-    : Export extends Dependency.AnyGlobal
+    : Export extends Dependency.AnyGlobal<ValueType>
     ? WebAssembly.Global
     : Export extends Dependency.AnyMemory
     ? WebAssembly.Memory

--- a/src/types.ts
+++ b/src/types.ts
@@ -33,6 +33,7 @@ export {
   printFunctionType,
   JSValue,
   Limits,
+  valueTypeSet,
 };
 
 type RefType = "funcref" | "externref";
@@ -77,6 +78,8 @@ const funcref = valueType("funcref");
 const externref = valueType("externref");
 
 const codeToValueType = invertRecord(valueTypeCodes);
+
+const valueTypeSet = new Set(Object.keys(valueTypeCodes) as ValueType[]);
 
 type ValueTypeObject = { kind: ValueType };
 const ValueType = Binable<ValueType>({

--- a/src/types.ts
+++ b/src/types.ts
@@ -106,8 +106,8 @@ const RefType = Binable<RefType>({
   },
 });
 
-type GlobalType = { value: ValueType; mutable: boolean };
-const GlobalType = record<GlobalType>({
+type GlobalType<T> = { value: T; mutable: boolean };
+const GlobalType = record<GlobalType<ValueType>>({
   value: ValueType,
   mutable: Bool,
 });


### PR DESCRIPTION
goal: the most common instructions should take stack arguments and support automatically adding const / local.get / global.get

- [x] infer global types and automatic `global.get`
- [x] `{local,global}.set`
- [x] memory instructions: store, load
