### PR TITLE
Fix repository link in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/zk-security/wasmati"
+    "url": "https://github.com/zksecurity/wasmati"
   },
   "dependencies": {
     "ieee754": "^1.2.1"


### PR DESCRIPTION
Otherwise, the repo link at https://www.npmjs.com/package/wasmati is broken.